### PR TITLE
Fix MacOS failure in StrongboxIndexerTest

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
@@ -215,7 +215,14 @@ public class TestArtifactContext implements AutoCloseable
 
         Files.delete(e.getValue());
     }
-    
+
+    /**
+     * This comparator will sort the paths in reverse alphabetical order, with
+     * checksum files ordered after other types of files.  This is necessary because
+     * Apache Maven Indexer's MinimalArtifactInfoIndexCreator will apply the checksum
+     * from a JAR file to the POM's entry in the index if the JAR file is added to the
+     * repository before the POM.
+     */
     private int repositoryPathChecksumComparator(RepositoryPath p1,
                                                  RepositoryPath p2)
             throws IOException
@@ -224,11 +231,11 @@ public class TestArtifactContext implements AutoCloseable
         Boolean isChecksumP2;
 
         isChecksumP1 = RepositoryFiles.isChecksum(p1);
-        isChecksumP2 = RepositoryFiles.isChecksum(p1);
+        isChecksumP2 = RepositoryFiles.isChecksum(p2);
         
-        if (isChecksumP1 && isChecksumP2)
+        if (isChecksumP1 && isChecksumP2 || !isChecksumP1 && !isChecksumP2)
         {
-            return p1.compareTo(p2);
+            return -1 * p1.compareTo(p2);
         }
         
         return isChecksumP1 ? 1 : -1;


### PR DESCRIPTION
# Pull Request Description

This fixes issue #.

# Acceptance Test

* [ ] Building the code with `mvn clean install -Dintegration.tests` still works.
* [ ] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [ ] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [ ] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [ ] No
